### PR TITLE
Fix for GPT-J models with `vocab_size % 8 != 0`

### DIFF
--- a/mtj_softtuner/core.py
+++ b/mtj_softtuner/core.py
@@ -532,7 +532,9 @@ def get_hf_conversion_callback(network, model_spec):
                         tensor /= network.config["cores_per_replica"]
                     if "vocab_pad" in transforms:
                         tensor = torch.nn.functional.pad(
-                            tensor, (0, 0, 0, network.config["n_vocab_padding"])
+                            tensor,
+                            (0,) * (tensor.ndim * 2 - 1)
+                            + (network.config["n_vocab_padding"],),
                         )
                     if "no_transpose" not in transforms and tensor.ndim == 2:
                         tensor = tensor.T


### PR DESCRIPTION
Refer to https://github.com/KoboldAI/KoboldAI-Client/pull/175 for more information.